### PR TITLE
fix filename generation by removing 'WOMAN:' and 'MAN:'

### DIFF
--- a/bark_speak.py
+++ b/bark_speak.py
@@ -90,7 +90,7 @@ def gen_and_save_audio(text_prompt,  history_prompt=None, text_temp=0.7, wavefor
 
     if not filename:
         date_str = datetime.datetime.now().strftime("%Y-%m-%d-%H")
-        truncated_text = text_prompt[:15].strip().replace(" ", "_")
+        truncated_text = text_prompt.replace("WOMAN:", "").replace("MAN:", "")[:15].strip().replace(" ", "_")
         filename = f"{truncated_text}-history_prompt-{history_prompt}-text_temp-{text_temp}-waveform_temp-{waveform_temp}-{date_str}.wav"
         filename = generate_unique_filename(filename)
 


### PR DESCRIPTION
adding 'WOMAN:' or 'MAN:' to the beginning of a text prompt was causing file generation to fail and instead generate a blank file named 'WOMAN' or 'MAN'.