### PR TITLE
Added `--less_gpu` switch for lower VRAM requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ _For music, I recommend using the --split_by_lines and making sure you use a mul
 --output_dir                 Output directory. Default is 'bark_samples'.
 --list_speakers              List all preset speaker options instead of generating audio.
 --use_smaller_models         Use for GPUs with less than 10GB of memory, or for more speed.
+--less_gpu                   To use the CPU for step 1 (text to semantic tokens) and a bit of final work, even if a GPU is present, to reduce VRAM requirements.
 --iterations                 Number of iterations. Default is 1.
 --split_by_words             Breaks text_prompt into <14 second audio clips every x words.
 --split_by_lines             Breaks text_prompt into <14 second audio clips every x lines.


### PR DESCRIPTION
This is the only way for me with a 6 GB GPU to use the regular (not small) models without using the CPU for *everything*, which would slow things down even more.

This should also make it possible to use the small models on GPUs with only 2 GB of VRAM.