### PR TITLE
Added bark_webui.bat for easy start

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,11 +87,15 @@ python bark_webui.py
 ```
 
 To restart later, start Miniforge Prompt. Then activate bark-infinity-oneclick (you can set it up to actiate automatically as well), and then:
+
+Option 1: Using commands
 ```
 mamba activate bark-infinity-oneclick
 cd bark
 python bark_webui.py
 ```
+
+Option 2: Run `bark-webui.bat` from Windows Explorer as normal, non-administrator, user.
 
 (If you do not have an NVIDIA GPU use `environment-cpu.yml` instead of `environment-cuda.yml`)
 

--- a/bark_webui.bat
+++ b/bark_webui.bat
@@ -1,0 +1,4 @@
+@echo off
+call %USERPROFILE%\mambaforge\Scripts\activate.bat bark-infinity-oneclick
+python %USERPROFILE%\bark\bark_webui.py
+pause


### PR DESCRIPTION
This pull request adds a new bark_webui.bat script that allows users to easily start the Bark web user interface on Windows. Users can now run the script directly from Windows Explorer without needing to manually activate the Mamba environment and navigate to the Bark directory.

Additionally, the README.md file has been updated to include instructions for using the new .bat file as an alternative method for starting the Bark web user interface.