### PR TITLE
Fix encoded format generation on command line

### DIFF
--- a/bark_infinity/api.py
+++ b/bark_infinity/api.py
@@ -7,7 +7,7 @@ from scipy.io.wavfile import write as write_wav
 from scipy.io import wavfile
 
 
-
+import tempfile
 import copy
 ## ADDED
 import os
@@ -430,21 +430,21 @@ def write_audiofile(output_filepath, audio_arr, **kwargs):
 
 
     if output_format in ['mp3', 'ogg', 'flac', 'mp4']:
-        temp_wav = "{output_filepath}.tmp.wav"
-        write_wav(temp_wav, SAMPLE_RATE, audio_arr) if not dry_run else None
-        if dry_run is not True:
-            audio = AudioSegment.from_wav(temp_wav)
-            """
-            sample_rate, wav_sample = scipy.io.wavfile.read(temp_wav) 
-            audio = AudioSegment(data=wav_sample.tobytes(),
-                            sample_width=2,
-                            frame_rate=sample_rate, channels=1)
-            """
-            if output_format == 'mp4':
-                audio.export(output_filepath, format="mp4", codec="aac")
-            else:
-                audio.export(output_filepath, format=output_format)
-            os.remove(temp_wav)
+        with tempfile.NamedTemporaryFile(suffix=".tmp.wav") as temp:
+            temp_wav = temp.name
+            write_wav(temp_wav, SAMPLE_RATE, audio_arr) if not dry_run else None
+            if dry_run is not True:
+                audio = AudioSegment.from_wav(temp_wav)
+                """
+                sample_rate, wav_sample = scipy.io.wavfile.read(temp_wav) 
+                audio = AudioSegment(data=wav_sample.tobytes(),
+                                sample_width=2,
+                                frame_rate=sample_rate, channels=1)
+                """
+                if output_format == 'mp4':
+                    audio.export(output_filepath, format="mp4", codec="aac")
+                else:
+                    audio.export(output_filepath, format=output_format)
     else:
         write_wav(output_filepath, SAMPLE_RATE, audio_arr) if not dry_run else None
 


### PR DESCRIPTION
This fixes generation of non-wav formats when running bark_perform.py on the commandline.

Detail: An incorrect format string `"{output_filepath}.tmp.wav"` which was likely intended to be `f"{output_filepath}.tmp.wav"` meant that the temporary wav file was not named correctly, causing the downstream `audio.export(output_filepath, format=output_format)` to fail.

Rather than just fixing the `f"{output_filepath}.tmp.wav"`, this PR uses a context manager to ensure the temporary file is always deleted after conversion.